### PR TITLE
exit baseBoostREG division (L141)

### DIFF
--- a/src/modifiers/boostBalancesDexs.ts
+++ b/src/modifiers/boostBalancesDexs.ts
@@ -138,7 +138,7 @@ export function boostBalancesDexs(
               }
 
               newEquivalentREG = applyV3Boost(
-                baseBoost / baseBoostREG,
+                baseBoost,
                 balance.equivalentREG,
                 balance.isActive || false,
                 effectiveValueLower,


### PR DESCRIPTION
Le Boost V3 s'applique au boost de base (et non à la valeur relative du boost de base / Boost de base du REG). Ligne 141 retrait de la division par baseBoostREG.